### PR TITLE
Total method now reloads object to calculate current value

### DIFF
--- a/lib/active_record/acts/shopping_cart/collection.rb
+++ b/lib/active_record/acts/shopping_cart/collection.rb
@@ -82,6 +82,7 @@ module ActiveRecord
         # Returns the total by summing the subtotal, taxes and shipping_cost
         #
         def total
+          reload
           subtotal + taxes + shipping_cost
         end
 

--- a/spec/active_record/acts/shopping_cart/collection_spec.rb
+++ b/spec/active_record/acts/shopping_cart/collection_spec.rb
@@ -206,7 +206,8 @@ describe ActiveRecord::Acts::ShoppingCart::Collection do
       allow(subject).to receive_messages(
         subtotal: Money.new(1099),
         taxes: Money.new(1399),
-        shipping_cost: Money.new(1299)
+        shipping_cost: Money.new(1299),
+        reload: nil
       )
     end
 


### PR DESCRIPTION
Hi,

This gem is really great and I will use it in my project. I'm using postgres as backend.

However, I noticed that when adding a product to the cart, and I call cart.total the total of the cart is actual. Now, when I add another product and call cart.total again it won't show the updated and actual total in the cart. Only when I reload the object and call cart.total again it shows the actual and current total value of the cart. I added reload to the total method. I checked the other methods and total appears the only method with this issue. I hope this makes sense. Thank you for considering.
